### PR TITLE
Add necessary trimmer files for not trimming COM types.

### DIFF
--- a/src/libraries/System.Transactions.Local/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/libraries/System.Transactions.Local/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -1,0 +1,12 @@
+<linker>
+  <assembly fullname="System.Transactions.Local" feature="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" featurevalue="true" featuredefault="true">
+    <!-- Imported COM interfaces -->
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.IResourceManager"/>
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.IResourceManagerFactory"/>
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.IResourceManagerFactory2"/>
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.IResourceManagerSink"/>
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.ITmNodeName"/>
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.ITransactionDispenser"/>
+    <type fullname="System.Transactions.DtcProxyShim.DTCInterfaces.ITransactionImportWhereabouts"/>
+  </assembly>
+</linker>

--- a/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -9,6 +9,9 @@
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
   </PropertyGroup>
   <ItemGroup>
+    <ILLinkDescriptorsXmls Condition="'$(TargetPlatformIdentifier)' == 'windows'" Include="$(ILLinkDirectory)ILLink.Descriptors.Windows.xml" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="System\Transactions\CommittableTransaction.cs" />
     <Compile Include="System\Transactions\DependentTransaction.cs" />
     <Compile Include="System\Transactions\DurableEnlistmentState.cs" />

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/IResourceManagerFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/IResourceManagerFactory.cs
@@ -8,9 +8,8 @@ namespace System.Transactions.DtcProxyShim.DTCInterfaces;
 [ComImport, Guid("13741d20-87eb-11ce-8081-0080c758527e"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface IResourceManagerFactory
 {
-    [PreserveSig]
-    public int Create(
-        in Guid pguidRM,
+    internal void Create(
+        Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
         [MarshalAs(UnmanagedType.Interface)] out IResourceManager rm);

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/IResourceManagerFactory2.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/IResourceManagerFactory2.cs
@@ -16,9 +16,8 @@ namespace System.Transactions.DtcProxyShim.DTCInterfaces;
 [ComImport, Guid("6B369C21-FBD2-11d1-8F47-00C04F8EE57D"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface IResourceManagerFactory2 : IResourceManagerFactory
 {
-    [PreserveSig]
-    public new int Create(
-        in Guid pguidRM,
+    internal new void Create(
+        Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
         [MarshalAs(UnmanagedType.Interface)] out IResourceManager rm);
@@ -36,10 +35,10 @@ internal interface IResourceManagerFactory2 : IResourceManagerFactory
     /// <param name="rm">
     /// Reference to the interface on the resource manager object whose IID is specified in the <paramref name="riidRequested" /> parameter.
     /// </param>
-    public void CreateEx(
-        in Guid pguidRM,
+    internal void CreateEx(
+        Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
-        in Guid riidRequested,
+        Guid riidRequested,
         [MarshalAs(UnmanagedType.Interface)] out object rm);
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/NotificationShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/NotificationShimFactory.cs
@@ -42,6 +42,7 @@ internal class NotificationShimFactory : IDtcProxyShimFactory
         // TODO: Instantiate all the locks (critical sections)
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2050", Justification = "Leave me alone")]
     public void ConnectToProxy(
         string nodeName,
         Guid resourceManagerIdentifier,


### PR DESCRIPTION
@roji The issue was that the trimmer was removing methods on the COM interfaces. It had originally looked like type confusion due to COM tear-offs being used, but I verified this wasn't the issue, rather the trimmer was augmenting COM interfaces and breaking vtable layouts.