### PR TITLE
Interface updates

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -377,7 +377,10 @@ namespace System.Threading
                 // If the handle is a repeating handle, set up the next call. Otherwise, remove it from the wait thread.
                 if (registeredHandle.Repeating)
                 {
-                    registeredHandle.RestartTimeout();
+                    if (!registeredHandle.IsInfiniteTimeout)
+                    {
+                        registeredHandle.RestartTimeout();
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/IResourceManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/IResourceManager.cs
@@ -51,7 +51,7 @@ internal interface IResourceManager
     internal void Reenlist(
         [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] byte[] pPrepInfo,
         uint cbPrepInfom,
-        int lTimeout,
+        uint lTimeout,
         [MarshalAs(UnmanagedType.I4)] out OletxXactStat pXactStat);
 
     /// <summary>

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransaction.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransaction.cs
@@ -22,7 +22,7 @@ internal interface ITransaction
     /// <param name="fRetainingt">Must be FALSE.</param>
     /// <param name="grfTC">Values taken from the <see cref="OletxXacttc" /> enumeration</param>
     /// <param name="grfRM">Must be zero.</param>
-    void Commit(bool fRetainingt, [MarshalAs(UnmanagedType.U4)] OletxXacttc grfTC, uint grfRM);
+    void Commit([MarshalAs(UnmanagedType.Bool)] bool fRetainingt, [MarshalAs(UnmanagedType.U4)] OletxXacttc grfTC, uint grfRM);
 
     /// <summary>
     /// This method aborts the transaction.
@@ -34,7 +34,7 @@ internal interface ITransaction
     /// <param name="async">
     /// When fAsync is true, an asynchronous abort is performed and the caller must use ITransactionOutcomeEvents to learn the outcome of the transaction.
     /// </param>
-    void Abort(IntPtr reason, int retaining, int async);
+    void Abort(IntPtr reason, [MarshalAs(UnmanagedType.Bool)] bool retaining, [MarshalAs(UnmanagedType.Bool)] bool async);
 
     /// <summary>
     /// This method returns information regarding a transaction object.

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionExportFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionExportFactory.cs
@@ -36,7 +36,7 @@ internal interface ITransactionExportFactory
     /// The caller uses the export object returned by this method to marshal a transaction object for export to the destination process.
     /// </param>
     void Create(
-        ulong cbWhereabouts,
+        uint cbWhereabouts,
         [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] byte[] rgbWhereabouts,
         [MarshalAs(UnmanagedType.Interface)] out ITransactionExport ppExport);
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionImport.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionImport.cs
@@ -26,7 +26,7 @@ internal interface ITransactionImport
     /// <param name="piid">The interface ID desired on the resulting transaction object.</param>
     /// <param name="ppvTransaction">Reference to the interface on the imported transaction object, requested by the <paramref name="piid" /> parameter.</param>
     void Import(
-        ulong cbTransactionCookie,
+        uint cbTransactionCookie,
         [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] byte[] rgbTransactionCookie,
         Guid piid,
         [MarshalAs(UnmanagedType.Interface)] out object ppvTransaction);

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionOutcomeEvents.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionOutcomeEvents.cs
@@ -23,7 +23,7 @@ internal interface ITransactionOutcomeEvents
     /// <param name="fRetaining">Indicates whether retaining Commit was specified. Will be false.</param>
     /// <param name="pNewUOW">Always null.</param>
     /// <param name="hresult">Always S_OK.</param>
-    void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW /* always null? */, uint hresult);
+    void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW /* always null? */, int hresult);
 
     /// <summary>
     /// This event is raised when the transaction aborted, either as a result of a call to Abort or an unsuccessful call to Commit*.*.
@@ -32,7 +32,7 @@ internal interface ITransactionOutcomeEvents
     /// <param name="fRetaining">Indicates whether retaining Commit was specified. Will be false.</param>
     /// <param name="pNewUOW">Always null.</param>
     /// <param name="hresult">Alawys S_OK.</param>
-    void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW, uint hresult);
+    void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW, int hresult);
 
     /// <summary>
     /// This event is raised when one of the participants in the transaction chooses to heuristically decide the outcome of the transaction.
@@ -40,7 +40,7 @@ internal interface ITransactionOutcomeEvents
     /// <param name="dwDecision">Values from the enumeration <see cref="OletxTransactionHeuristic" />.</param>
     /// <param name="pboidReason">A BOID indicating why the transaction was heuristically decided. This value is provided by the party making the heuristic decision.</param>
     /// <param name="hresult">Always S_OK.</param>
-    void HeuristicDecision([MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision, IntPtr pboidReason, uint hresult);
+    void HeuristicDecision([MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision, IntPtr pboidReason, int hresult);
 
     /// <summary>
     /// This event is raised when the outcome of the transaction is in-doubt.

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionResourceAsync.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionResourceAsync.cs
@@ -37,7 +37,7 @@ internal interface ITransactionResourceAsync
     /// </summary>
     /// <param name="grfRM">Values from <see cref="OletxXactRm" />.</param>
     /// <param name="pNewUOW">Always null.</param>
-    void CommitRequest(OletxXactRm grfRM, Guid pNewUOW);
+    void CommitRequest(OletxXactRm grfRM, IntPtr pNewUOW);
 
     /// <summary>
     /// The DTC proxy calls this method to abort a transaction.
@@ -45,7 +45,7 @@ internal interface ITransactionResourceAsync
     /// <param name="pboidReason">Unspecified and should be ignored.</param>
     /// <param name="fRetaining">Always will be false.</param>
     /// <param name="pNewUOW">Always will be null.</param>
-    void AbortRequest(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW);
+    void AbortRequest(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW);
 
     /// <summary>
     /// The DTC Proxy calls on this method if the connection to the transaction manager goes down and the resource manager's transaction object is prepared

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionVoterNotifyAsync2.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DTCInterfaces/ITransactionVoterNotifyAsync2.cs
@@ -24,7 +24,7 @@ internal interface ITransactionVoterNotifyAsync2
     /// <param name="fRetaining">Indicates whether retaining Commit was specified. Will be false.</param>
     /// <param name="pNewUOW">Always null.</param>
     /// <param name="hresult">Always S_OK.</param>
-    void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW /* always null? */, uint hresult);
+    void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW /* always null? */, uint hresult);
 
     /// <summary>
     /// This event is raised when the transaction aborted, either as a result of a call to Abort or an unsuccessful call to Commit*.*.
@@ -33,7 +33,7 @@ internal interface ITransactionVoterNotifyAsync2
     /// <param name="fRetaining">Indicates whether retaining Commit was specified. Will be false.</param>
     /// <param name="pNewUOW">Always null.</param>
     /// <param name="hresult">Alawys S_OK.</param>
-    void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW, uint hresult);
+    void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW, uint hresult);
 
     /// <summary>
     /// This event is raised when one of the participants in the transaction chooses to heuristically decide the outcome of the transaction.

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/EnlistmentNotifyShim.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/EnlistmentNotifyShim.cs
@@ -51,13 +51,13 @@ internal sealed class EnlistmentNotifyShim : NotificationShimBase, ITransactionR
         ShimFactory.NewNotification(this);
     }
 
-    public void CommitRequest(OletxXactRm grfRM, Guid pNewUOW)
+    public void CommitRequest(OletxXactRm grfRM, IntPtr pNewUOW)
     {
         NotificationType = ShimNotificationType.CommitRequestNotify;
         ShimFactory.NewNotification(this);
     }
 
-    public void AbortRequest(IntPtr pboidReason, bool fRetaining, Guid pNewUOW)
+    public void AbortRequest(IntPtr pboidReason, bool fRetaining, IntPtr pNewUOW)
     {
         if (!_ignoreSpuriousProxyNotifications)
         {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/TransactionNotifyShim.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/TransactionNotifyShim.cs
@@ -14,19 +14,19 @@ internal sealed class TransactionNotifyShim : NotificationShimBase, ITransaction
     {
     }
 
-    public void Committed(bool fRetaining, Guid pNewUOW /* always null? */, uint hresult)
+    public void Committed(bool fRetaining, IntPtr pNewUOW /* always null? */, int hresult)
     {
         NotificationType = ShimNotificationType.CommittedNotify;
         ShimFactory.NewNotification(this);
     }
 
-    public void Aborted(IntPtr pboidReason, bool fRetaining, Guid pNewUOW, uint hresult)
+    public void Aborted(IntPtr pboidReason, bool fRetaining, IntPtr pNewUOW, int hresult)
     {
         NotificationType = ShimNotificationType.AbortedNotify;
         ShimFactory.NewNotification(this);
     }
 
-    public void HeuristicDecision(OletxTransactionHeuristic dwDecision, IntPtr pboidReason, uint hresult)
+    public void HeuristicDecision(OletxTransactionHeuristic dwDecision, IntPtr pboidReason, int hresult)
     {
         NotificationType = dwDecision switch
         {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/TransactionShim.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/TransactionShim.cs
@@ -38,7 +38,7 @@ internal sealed class TransactionShim : ITransactionShim
 
     public void Export(byte[] whereabouts, out byte[] cookieBuffer)
     {
-        _shimFactory.ExportFactory.Create((ulong)whereabouts.Length, whereabouts, out ITransactionExport export);
+        _shimFactory.ExportFactory.Create((uint)whereabouts.Length, whereabouts, out ITransactionExport export);
 
         uint cookieSizeULong = 0;
 

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/VoterNotifyShim.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/VoterNotifyShim.cs
@@ -21,9 +21,9 @@ internal sealed class VoterNotifyShim : NotificationShimBase, ITransactionVoterN
     }
 
     // TODO
-    public void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW, uint hresult)
+    public void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW, uint hresult)
         => throw new NotImplementedException();
-    public void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, Guid pNewUOW, uint hresult)
+    public void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW, uint hresult)
         => throw new NotImplementedException();
     public void HeuristicDecision([MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision, IntPtr pboidReason, uint hresult)
         => throw new NotImplementedException();


### PR DESCRIPTION
This fixes several issue when using a DBG/CHK runtime. One of them was a subtle assert bug in the WaitHandles logic, but the others were around incorrect COM interface definitions. The biggest problem was cases where the COM interface indicated a value was optional. However, the signature indicated the value would be a ValueType, this means the marshallers would try to dereference the pointer and marshal because we have no real way of expressing this optional concept in a COM signature. Since I noted the cases were all for types that were always going to be null I make the argument `IntPtr`.

There is still an issue, but I don't believe it is related to COM definitions. The call stack and image are below - the issue is `FailFast()` is being called from within `ShimNotificationCallback`.

![image](https://user-images.githubusercontent.com/30635565/179119408-2100f283-aad9-434a-8471-708c203b81d8.png)
